### PR TITLE
Naming and creds

### DIFF
--- a/lib/libknc.c
+++ b/lib/libknc.c
@@ -74,7 +74,7 @@ struct knc_stream {
 	struct knc_stream_gc	*garbage;
 	size_t			 bufpos;
 	size_t			 avail;
-	char			*failed_func;
+	const char		*failed_func;
 	int			 errnum;
 };
 
@@ -2511,7 +2511,7 @@ knc_syscall_error(knc_ctx ctx, const char *str, int number)
 }
 
 static void
-knc_nomem(knc_ctx ctx)
+knc_enomem(knc_ctx ctx)
 {
     knc_syscall_error(ctx, "Out of memory", ENOMEM);
 }
@@ -2535,11 +2535,4 @@ knc_gss_error(knc_ctx ctx, OM_uint32 maj_stat, OM_uint32 min_stat,
 	if (!ctx->errstr)
 		ctx->errstr = strdup("Failed to construct GSS error");
 	KNCDEBUG(ctx, ("knc_gss_error: %s\n", ctx->errstr));
-}
-
-static void
-knc_enomem(knc_ctx ctx)
-{
-
-	knc_syscall_error(ctx, "Out of memory", ENOMEM);
 }


### PR DESCRIPTION
These commits make the API a bit more symmetric and allow more control (and document it) over when credentials are released, which is useful for privilege dropping purposes.

We should do something even more likely to drop access to privileged data: provide an export/import interface so you can: a) export a knc context, b) exec a child and pass it the exported context via an open, unlinked tmp file or shared memory, c) re-import the context.  Actually, this needn't even look like an export/import pair of functions, more like:

int
knc_allow_inherit(knc_ctx); /\* returns an fd to import from */

void
knc_ctx knc_inherit(int);

Even the knc_stream info, including fildes numbers, needed for the event loop should be passed via this one fd.

So an app would accept a context, knc_set_cred(ctx, GSS_C_NO_CREDENTIAL), do something with the deleg cred (possibly gss_export_cred(), possibly gss_store_cred()), knc_free_deleg_cred(ctx), then fork(), knc_allow_inherit(), setuid() and so on, then exec(), then knc_inherit().
